### PR TITLE
Fixes wrong radius selection after training

### DIFF
--- a/flod/classifiers/bsvclassifier.py
+++ b/flod/classifiers/bsvclassifier.py
@@ -161,8 +161,10 @@ class BSVClassifier(ClassifierMixin, BaseEstimator):
         v = np.sqrt(v)
         return v
 
-    def _best_radius(self) -> float:        
-        return np.average([self._compute_r(x) for x in self.X_train_], weights=[b / self.c for b in self.betas_])
+    def _best_radius(self) -> float:
+        sv = [x for b, x in zip(self.betas_, self.X_train_) if not np.isclose(b, self.c) and not np.isclose(b, 0)]
+        assert len(sv) > 0, 'Cannot compute best radius. Missing support vectors. Maybe something went wrong during training?'
+        return np.average([self._compute_r(x) for x in sv])
 
     def decision_function(self, X):
         #Like sklearn OneClassSVM "Signed distance is positive for an inlier and negative for an outlier.""


### PR DESCRIPTION
After the training, the goal of the `best_radius` function is to return the radius that will act as the threshold in the prediction phase.
Any point with a radius greater than the best_radius one will be classified as an outlier.

In theory, to correctly compute it one should pick a support vector $x$, defined as a point with its multiplier $\beta$ in the interval (0,C). However, due to potential computation issues in the optimization phase, I employ the average to get a more robust result.

The previous code however counted even the BSVs. These are the points with $\beta = C$. 
Actually, they are more rewarded than the actual support vectors